### PR TITLE
Path to catch SuperAgent errors when accessing the Keen.io API...

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,11 +20,18 @@ function KeenApi(config) {
 	var baseUrl = this.baseUrl;
 	var apiVersion = this.apiVersion;
 
+	var handleAgentError = function(message, err) {
+		console.log("ERROR: " + message + ": " + err);
+	}
+
 	var request = {
 		get: function(apiKey, path, callback) {
 			rest
 				.get(baseUrl + apiVersion + path)
 				.set('Authorization', apiKey)
+				.on('error', function(err) {
+					handleAgentError("HTTPS 'get' agent", err);
+				})
 				.end(function(res) {
 					processResponse(res, callback);
 				});
@@ -35,6 +42,9 @@ function KeenApi(config) {
 				.set('Authorization', apiKey)
 				.set('Content-Type', 'application/json')
 				.send(data || {})
+				.on('error', function(err) {
+					handleAgentError("HTTPS 'post' agent", err);
+				})
 				.end(function(res) {
 					processResponse(res, callback);
 				});
@@ -44,6 +54,9 @@ function KeenApi(config) {
 				.del(baseUrl + apiVersion + path)
 				.set('Authorization', apiKey)
 				.set('Content-Length', 0)
+				.on('error', function(err) {
+					handleAgentError("HTTPS 'delete' agent", err);
+				})
 				.end(function(res) {
 					processResponse(res, callback);
 				});


### PR DESCRIPTION
Hey Daniel,

This may not be the way you want to handle errors, but it's been helpful for me.  I wrote a tool to simulate multiple devices sending stats to Keen, and I noticed that I was occasionally getting 'Error: socket hang up' errors, causing the script to stop.  I add SuperAgent's '.on' method to the call chain to catch the errors and display a message.  I could probably just use process.on('error', blah), but I did not want to catch all of the other errors.  Passing this along in case it's useful...

Thanks!
Mark
