### PR TITLE
[FEATURE] Flushing Support for addEvent()/addEvents() 

### DIFF
--- a/examples/flush-events.js
+++ b/examples/flush-events.js
@@ -1,0 +1,43 @@
+var keen = require('../index.js'),
+    keenClient = keen.configure({
+        projectId: "<project-key>",
+        writeKey: "<write-key>",
+        /*flush: {
+            atEventQuantity: 1,
+            afterTime: 500    
+        }*/
+    });
+
+// Construct same events
+var event = {
+    data: {
+        name: 'Fred',
+        age: 30
+    },
+    keen: {
+        timestamp: new Date(0) // overwrite the recorded keen timestamp
+    }
+};
+
+var otherEvent = {
+    data: {
+        name: 'John',
+        age: 40
+    }
+};
+
+var finalEvent = {
+    data: {
+        name: 'John Smith',
+        age: 20
+    }
+};
+
+var respond = function (err, res) {
+    console.log('event.insert', err, res);
+};
+
+// Send events to project
+keenClient.addEvent('flush-test', event, respond);
+keenClient.addEvent('flush-test', otherEvent, respond);
+keenClient.addEvent('flush-test', finalEvent, respond);

--- a/index.js
+++ b/index.js
@@ -213,13 +213,38 @@ function KeenApi(config) {
 
 	/**
 	 * Enqueues a message onto `this._queue`.
-	 * @param {Object} requestData Data to send to Keen.IO.
+	 * @param {Object} requestData Event data to send to Keen.IO.
 	 */
 	this._enqueue = function (requestData) {
 		var promise = requestData.promise;
 		promise.end(function(err, res) {
 			processResponse(err, res, requestData.callback);
 		});
+	};
+
+	/**
+	 * Starts and sets a timer at `this._timer`. Timer checks whether it should 
+	 * be flushing - generally: too long has passed since last flush and the queue
+	 * contains events.
+	 */
+	this._setTimer = function () {
+		var self = this;
+		if (!this._timer) {
+			this._timer = setInterval(function () {
+				self._checkFlush.apply(self);
+			}, this._flushOptions.timerInterval);
+		}
+	};
+
+	/**
+	 * Stops and clears the timer at `this._timer`. Afterwards: no longer checking 
+	 * to see whether the queue should be flushed.
+	 */
+	this._clearTimer = function () {
+		if (this._timer) {
+			clearInterval(this._timer);
+			this._timer = null;
+		}
 	};
 }
 

--- a/index.js
+++ b/index.js
@@ -223,15 +223,15 @@ function KeenApi(config) {
 		var enqueued = false;
 		if (this._queue.length >= this._flushOptions.maxQueueSize) {
 			console.error('KeenClient-Node failed to enqueue the event because the queue is full. ' +
-				        'Consider increasing the queue size.')
+				          'Consider increasing the queue size.')
 		} else {
 			this._queue.push(requestData);
 			this._setTimer();
 			enqueued = true;
-		}
 
-		if (enqueued && this._shouldFlush()) {
-			this.flush();
+			if (this._shouldFlush()) {
+				this.flush();
+			}
 		}
 
 		return enqueued;
@@ -282,15 +282,18 @@ function KeenApi(config) {
 	};
 
 	/**
-	 * Starts and sets a timer at `this._timer`. Timer checks whether it should 
-	 * be flushing - generally: N milliseconds has passed since the last flush
-	 * and the queue contains events.
+	 * Starts and sets a timer at `this._timer`.
+	 * Timer checks whether it should be flushing - generally:
+	 * N milliseconds has passed since the last flush or the queue contains events. 
+	 * It flushes if this is the case.
 	 */
 	this._setTimer = function () {
 		var self = this;
 		if (!this._timer) {
 			this._timer = setInterval(function () {
-				self._shouldFlush.apply(self);
+				if (self._shouldFlush.apply(self)) {
+					self.flush.apply(self);
+				}
 			}, this._flushOptions.timerInterval);
 		}
 	};

--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ function KeenApi(config) {
 				}
 				data[collection].push(item);
 			});
-			request.post(this.writeKey, '/projects/' + projectId + '/events', data, callback);
+			request.queuePost(this.writeKey, '/projects/' + projectId + '/events', data, callback);
 		}
 	};
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function KeenApi(config) {
 
 	this._flushOptions = _.extend({
 		atEventQuantity: 20,
-		afterTime: 10000, 
+		afterTime: 10000,
 		maxQueueSize: 10000,
 		timerInterval: 10000
 	}, config.flush || {})
@@ -36,35 +36,35 @@ function KeenApi(config) {
 
 	var self = this;
 	var request = {
-		get: function(apiKey, path, callback) {
+		get: function (apiKey, path, callback) {
 			rest
 				.get(baseUrl + apiVersion + path)
 				.set('Authorization', apiKey)
-				.end(function(err, res) {
+				.end(function (err, res) {
 					processResponse(err, res, callback);
 				});
 		},
-		post: function(apiKey, path, data, callback) {
+		post: function (apiKey, path, data, callback) {
 			data = data || {};
 			rest
 				.post(baseUrl + apiVersion + path)
 				.set('Authorization', apiKey)
 				.set('Content-Type', 'application/json')
 				.send(data)
-				.end(function(err, res) {
+				.end(function (err, res) {
 					processResponse(err, res, callback);
 				});
 		},
-		del: function(apiKey, path, callback) {
+		del: function (apiKey, path, callback) {
 			rest
 				.del(baseUrl + apiVersion + path)
 				.set('Authorization', apiKey)
 				.set('Content-Length', 0)
-				.end(function(err, res) {
+				.end(function (err, res) {
 					processResponse(err, res, callback);
 				});
 		},
-		queuePost: function(apiKey, path, data, callback) {
+		queuePost: function (apiKey, path, data, callback) {
 			data = data || {};
 			var promise = rest
 				.post(baseUrl + apiVersion + path)
@@ -77,7 +77,7 @@ function KeenApi(config) {
 				promise: promise,
 				callback: callback
 			};
-			
+
 			self._enqueue(requestData);
 
 			return promise;
@@ -87,7 +87,7 @@ function KeenApi(config) {
 	// Handle logic of processing response, including error messages
 	// The error handling should be strengthened over time to be more meaningful and robust
 	function processResponse(err, res, callback) {
-		callback = callback || function() {};
+		callback = callback || function () {};
 
 		if (res && !res.ok && !err) {
 			var is_err = res.body && res.body.error_code;
@@ -102,22 +102,22 @@ function KeenApi(config) {
 	// Public Methods
 
 	this.projects = {
-		list: function(callback) {
+		list: function (callback) {
 			request.get(this.masterKey, '/projects', callback);
 		},
-		view: function(projectId, callback) {
+		view: function (projectId, callback) {
 			request.get(this.masterKey, '/projects/' + projectId, callback);
 		}
 	};
 
 	this.events = {
-		list: function(projectId, callback) {
+		list: function (projectId, callback) {
 			request.get(this.masterKey, '/projects/' + projectId + '/events', callback);
 		},
-		insert: function(projectId, events, callback) {
+		insert: function (projectId, events, callback) {
 			events = events || [];
 			var data = {};
-			events.forEach(function(event) {
+			events.forEach(function (event) {
 				var collection = event.collection;
 				if (typeof data[collection] == 'undefined') {
 					data[collection] = [];
@@ -133,30 +133,30 @@ function KeenApi(config) {
 	};
 
 	this.properties = {
-		view: function(projectId, collection, property, callback) {
+		view: function (projectId, collection, property, callback) {
 			request.get(this.masterKey, '/projects/' + projectId + '/events/' + collection + '/properties/' + property, callback);
 		},
-		remove: function(projectId, collection, property, callback) {
+		remove: function (projectId, collection, property, callback) {
 			request.del(this.masterKey, '/projects/' + projectId + '/events/' + collection + '/properties/' + property, callback);
 		}
 	};
 
 	this.collections = {
-		view: function(projectId, collection, callback) {
+		view: function (projectId, collection, callback) {
 			request.get(this.masterKey, '/projects/' + projectId + '/events/' + collection, callback);
 		},
-		remove: function(projectId, collection, callback) {
+		remove: function (projectId, collection, callback) {
 			request.del(this.masterKey, '/projects/' + projectId + '/events/' + collection, callback);
 		}
 	};
 
-	this.request = function(method, keyType, path, params, callback) {
+	this.request = function (method, keyType, path, params, callback) {
 		method = typeof method === 'string' && method.toLowerCase();
 		keyType += 'Key';
 		callback = callback || (typeof params === 'function') && params;
 
 		if (typeof path === 'string') {
-			path = '/projects/' + this.projectId + '/' + path.replace(/^\//,'');
+			path = '/projects/' + this.projectId + '/' + path.replace(/^\//, '');
 		} else {
 			throw new Error('\'path\' must be a string.');
 		}
@@ -165,7 +165,7 @@ function KeenApi(config) {
 			path += '?' + qs.stringify(params);
 		}
 
-		if ( ! request.hasOwnProperty(method)) {
+		if (!request.hasOwnProperty(method)) {
 			throw new Error('Method must be of type: GET/POST/DEL');
 		}
 
@@ -177,14 +177,14 @@ function KeenApi(config) {
 			throw new Error('You must specify a nun-null, non-empty \'' + keyType + '\' in your config object.');
 		}
 
-		if(method === 'post') {
+		if (method === 'post') {
 			return request.post(this[keyType], path, params, callback);
 		}
 
 		request[method](this[keyType], path, callback);
 	};
 
-	this.addEvent = function(eventCollection, event, callback) {
+	this.addEvent = function (eventCollection, event, callback) {
 		if (!this.writeKey) {
 			var errorMessage = "You must specify a non-null, non-empty 'writeKey' in your 'config' object when calling keen.configure()!";
 			var error = new Error(errorMessage);
@@ -199,7 +199,7 @@ function KeenApi(config) {
 		request.queuePost(this.writeKey, "/projects/" + this.projectId + "/events/" + eventCollection, event, callback);
 	};
 
-	this.addEvents = function(events, callback) {
+	this.addEvents = function (events, callback) {
 		if (!this.writeKey) {
 			var errorMessage = "You must specify a non-null, non-empty 'writeKey' in your 'config' object when calling keen.configure()!";
 			var error = new Error(errorMessage);
@@ -223,7 +223,7 @@ function KeenApi(config) {
 		var enqueued = false;
 		if (this._queue.length >= this._flushOptions.maxQueueSize) {
 			console.error('KeenClient-Node failed to enqueue the event because the queue is full. ' +
-				          'Consider increasing the queue size.')
+				'Consider increasing the queue size.')
 		} else {
 			this._queue.push(requestData);
 			this._setTimer();
@@ -267,7 +267,7 @@ function KeenApi(config) {
 		// Do each of the requests in the queue group.
 		_.each(queueGroup, function (e) {
 			var promise = e.promise;
-			promise.end(function(err, res) {
+			promise.end(function (err, res) {
 				processResponse(err, res, e.callback);
 			});
 		});
@@ -284,7 +284,7 @@ function KeenApi(config) {
 	/**
 	 * Starts and sets a timer at `this._timer`.
 	 * Timer checks whether it should be flushing - generally:
-	 * N milliseconds has passed since the last flush or the queue contains events. 
+	 * N milliseconds has passed since the last flush or the queue contains events.
 	 * It flushes if this is the case.
 	 */
 	this._setTimer = function () {
@@ -299,7 +299,7 @@ function KeenApi(config) {
 	};
 
 	/**
-	 * Stops and clears the timer at `this._timer`. Afterwards: no longer checking 
+	 * Stops and clears the timer at `this._timer`. Afterwards: no longer checking
 	 * to see whether the queue should be flushed.
 	 */
 	this._clearTimer = function () {

--- a/index.js
+++ b/index.js
@@ -18,6 +18,9 @@ function KeenApi(config) {
 	this.baseUrl = config.baseUrl || 'https://api.keen.io/';
 	this.apiVersion = config.apiVersion || '3.0';
 
+	this._queue = [];
+	this._lastFlush = new Date(0);
+
 	var baseUrl = this.baseUrl;
 	var apiVersion = this.apiVersion;
 

--- a/index.js
+++ b/index.js
@@ -233,7 +233,7 @@ function KeenApi(config) {
 			shouldFlush;
 
 		shouldFlush = _.reduce(this._triggers, function (shouldFlush, unboundTrigger) {
-			shouldFlush = shouldFlush || unboundTrigger.apply(self);
+			return shouldFlush || unboundTrigger.apply(self);
 		}, false);
 
 		return shouldFlush;

--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@ var _ = require('underscore');
 var crypto = require('crypto');
 var qs = require('querystring');
 
+var triggers = require('./lib/triggers');
+
 function KeenApi(config) {
 	if (!config) {
 		throw new Error("The 'config' parameter must be specified and must be a JS object.");
@@ -25,6 +27,7 @@ function KeenApi(config) {
 		timerInterval: 10000
 	}, config.flush || {})
 
+	this._triggers = triggers;
 	this._queue = [];
 	this._lastFlush = new Date(0);
 
@@ -220,6 +223,27 @@ function KeenApi(config) {
 		promise.end(function(err, res) {
 			processResponse(err, res, requestData.callback);
 		});
+	};
+
+	/**
+	 *
+	 */
+	this._checkFlush = function () {
+		var self = this,
+			shouldFlush;
+
+		shouldFlush = _.reduce(this._triggers, function (shouldFlush, unboundTrigger) {
+			shouldFlush = shouldFlush || unboundTrigger.apply(self);
+		}, false);
+
+		return shouldFlush;
+	};
+
+	/**
+	 *
+	 */
+	this.flush = function () {
+
 	};
 
 	/**

--- a/index.js
+++ b/index.js
@@ -18,6 +18,13 @@ function KeenApi(config) {
 	this.baseUrl = config.baseUrl || 'https://api.keen.io/';
 	this.apiVersion = config.apiVersion || '3.0';
 
+	this._flushOptions = _.extend({
+		atEventQuantity: 20,
+		afterTime: 10000, 
+		maxQueueSize: 10000,
+		timerInterval: 10000
+	}, config.flush || {})
+
 	this._queue = [];
 	this._lastFlush = new Date(0);
 

--- a/index.js
+++ b/index.js
@@ -260,17 +260,17 @@ function KeenApi(config) {
 			return false;
 		}
 
-        // If the queue length is non-zero, then:
-        // create a group by splicing up until `this._flushOptions.atEventQuantity`
-        var queueGroup = this._queue.splice(0, this._flushOptions.atEventQuantity);
+		// If the queue length is non-zero, then:
+		// create a group by splicing up until `this._flushOptions.atEventQuantity`
+		var queueGroup = this._queue.splice(0, this._flushOptions.atEventQuantity);
 
-	    // Do each of the requests in the queue group.
-	    _.each(queueGroup, function (e) {
+		// Do each of the requests in the queue group.
+		_.each(queueGroup, function (e) {
 			var promise = e.promise;
 			promise.end(function(err, res) {
 				processResponse(err, res, e.callback);
 			});
-	    });
+		});
 
 		this._lastFlush = new Date();
 

--- a/lib/triggers.js
+++ b/lib/triggers.js
@@ -1,9 +1,9 @@
 var triggers = module.exports;
 
 triggers.isQueueBeyondLimit = function () {
-    return this._queue.length >= this.options.flushAt;
+    return this._queue.length >= this._flushOptions.atEventQuantity;
 };
 
 triggers.hasTimePassedSinceLastFlush = function () {
-    return Date.now() - this._lastFlush > this.options.flushAfter;
+    return Date.now() - this._lastFlush > this._flushOptions.afterTime;
 };

--- a/lib/triggers.js
+++ b/lib/triggers.js
@@ -1,5 +1,10 @@
 var triggers = module.exports;
 
+// By default the library will flush:
+// * On the first event.
+// * Every `this._flushOptions.atEventQuantity` events.
+// * If `this._flushOptions.afterTime` milliseconds has passed since the last flush.
+
 triggers.isQueueBeyondLimit = function () {
     return this._queue.length >= this._flushOptions.atEventQuantity;
 };

--- a/lib/triggers.js
+++ b/lib/triggers.js
@@ -1,0 +1,9 @@
+var triggers = module.exports;
+
+triggers.isQueueBeyondLimit = function () {
+    return this._queue.length >= this.options.flushAt;
+};
+
+triggers.hasTimePassedSinceLastFlush = function () {
+    return Date.now() - this._lastFlush > this.options.flushAfter;
+};

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "mocha": "~1.16.1",
     "should": "~2.1.1",
-    "nock": "~0.27.0"
+    "nock": "~0.27.0",
+    "sinon": "1.7.3"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -319,8 +319,8 @@ describe("keen", function() {
         //        and logging to see when and how flushing is executed.
 
         // By default the library will flush:
-        // * [ ] Every N messages.
-        // * [ ] If S milliseconds has passed since the last flush.
+        // * [x] Every N messages.
+        // * [x] If S milliseconds has passed since the last flush.
 
         // Notes:
         // * [x] Before flushing a message contains a promise.
@@ -334,67 +334,86 @@ describe("keen", function() {
         // * [x] Check things are constructed correctly.
         // * [x] Create small triggers.
         // * [ ] Implement _enqueue().
-        // * [ ] Implement _checkFlush().
+        // * [x] Implement _checkFlush().
         // * [ ] Implement flush().
         // * [x] Implement _setTimer and _clearTimer().
 
         describe('_enqueue()', function () {
 
-            it('should drop data if the queue has expanded beyond the max queue size', function () {
+            xit('should drop data if the queue has expanded beyond the max queue size', function () {
 
             });
 
-            it('should push to the queue on normal operation', function () {
+            xit('should push to the queue on normal operation', function () {
 
             });
 
-            it('should set the timer, if it has not been set already', function () {
+            xit('should set the timer, if it has not been set already', function () {
 
             });
 
-            it('should call flush if _checkFlush() returns true', function () {
+            xit('should call flush if _checkFlush() returns true', function () {
 
             });
         });
 
         describe('_checkFlush()', function () {
 
-            it("should return true if too much time passed since last flush", function () {
-
-            });
-
-            it("should return true if the length of the queue is too large", function () {
-
-            });
-
             it("should return false if neither of the triggers returned true", function () {
+                keen._flushOptions.atEventQuantity = 10000;             
+                keen._flushOptions.afterTime = 1000000;
+                keen._queue = [];   
+                keen._lastFlush = new Date();
 
+                keen._checkFlush().should.be.false;
+            });
+
+            it("should return true if too much time passed since last flush", function () {
+                keen._flushOptions.atEventQuantity = 10000;             
+                keen._flushOptions.afterTime = 10000;
+                keen._queue = [];  
+
+                var timeHasPassedSinceThis = new Date();
+                timeHasPassedSinceThis = timeHasPassedSinceThis.setDate(timeHasPassedSinceThis.getDate() - 7);
+                keen._lastFlush = timeHasPassedSinceThis;
+                
+                keen._checkFlush().should.be.true;
+            });
+
+            it("should return true if the length of the queue is too large", function () {            
+                keen._flushOptions.afterTime = 1000000;
+                keen._lastFlush = new Date();
+
+                keen._flushOptions.atEventQuantity = 5;
+                keen._queue = [1, 2, 3, 4, 5, 6];
+
+                keen._checkFlush().should.be.true;
             });
 
         });
 
         describe('flush()', function () {
 
-            it('should do nothing when the queue is empty', function () {
+            xit('should do nothing when the queue is empty', function () {
 
             });
 
-            it('should reduce the size of the queue by atEventQuantity', function () {
+            xit('should reduce the size of the queue by atEventQuantity', function () {
                 // If the queue length is non-zero, then...
                 // create a batch by splicing up until `this.options.flushAt`
                 // also, test that this reduces the size of the queue.
             });
 
-            it('should fulfill the queues promises', function () {
+            xit('should fulfill the queues promises', function () {
                 // Get a list of promises.
                 // Make each of the requests in the batch.
             })
 
-            it('should set _lastFlush with the current date', function () {
+            xit('should set _lastFlush with the current date', function () {
                 // Set `this._lastFlush` to the current date.
             });
 
-            it('should call _clearTimer if the queue hits zero', function () {
+            xit('should call _clearTimer if the queue hits zero', function () {
                 // If the queue length gets to zero, then clear the timer.
             });
 

--- a/test/test.js
+++ b/test/test.js
@@ -243,6 +243,8 @@ describe("keen", function() {
 
     describe('flushing', function () {
 
+        var sinon = require('sinon');
+
         // First things first:
         // * [x] A small refactor to handle promises/callbacks better.
         //       We need to get the promise.
@@ -337,43 +339,65 @@ describe("keen", function() {
         // * [x] Implement _setTimer and _clearTimer().
 
         describe('_enqueue()', function () {
-            // Drop data if the queue has expanded beyond the max queue size.
-            // Log an error message.
 
-            // Push to the queue.
+            it('should drop data if the queue has expanded beyond the max queue size', function () {
 
-            // Check to see whether the timer was set.
+            });
 
-            // Check whether it should be flushing.
+            it('should push to the queue on normal operation', function () {
+
+            });
+
+            it('should set the timer, if it has not been set already', function () {
+
+            });
+
+            it('should call flush if _checkFlush() returns true', function () {
+
+            });
         });
 
         describe('_checkFlush()', function () {
-            // @todo: To begin with just flush immediately.
 
-            // then:
+            it("should return true if too much time passed since last flush", function () {
 
-            // Loop through the triggers, whichs should be set against the client.
-            // *OR* with a variable `shouldFlush`, on triggering against the scope.
+            });
 
-            // Call flush if true, and false otherwise.
+            it("should return true if the length of the queue is too large", function () {
 
-            // Return true or false.
+            });
+
+            it("should return false if neither of the triggers returned true", function () {
+
+            });
+
         });
 
         describe('flush()', function () {
-            // Given an empty queue, do nothing.
 
-            // If the queue length is non-zero, then...
-            // create a batch by splicing up until `this.options.flushAt`
-            // also, test that this reduces the size of the queue.
+            it('should do nothing when the queue is empty', function () {
 
-            // Get a list of promises.
+            });
 
-            // Make each of the requests in the batch.
+            it('should reduce the size of the queue by atEventQuantity', function () {
+                // If the queue length is non-zero, then...
+                // create a batch by splicing up until `this.options.flushAt`
+                // also, test that this reduces the size of the queue.
+            });
 
-            // Set `this._lastFlush` to the current date.
+            it('should fulfill the queues promises', function () {
+                // Get a list of promises.
+                // Make each of the requests in the batch.
+            })
 
-            // If the queue length gets to zero, then clear the timer.
+            it('should set _lastFlush with the current date', function () {
+                // Set `this._lastFlush` to the current date.
+            });
+
+            it('should call _clearTimer if the queue hits zero', function () {
+                // If the queue length gets to zero, then clear the timer.
+            });
+
         });
 
         describe('_setTimer', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -38,6 +38,13 @@ describe("keen", function() {
         keen.baseUrl.should.equal("https://api.keen.io/");
         keen.apiVersion.should.equal("3.0");
 
+        keen._flushOptions.should.eql({
+            atEventQuantity: 20,
+            afterTime: 10000, 
+            maxQueueSize: 10000,
+            timerInterval: 10000
+        });
+
         keen._queue.should.eql([]);
         keen._lastFlush.should.be.instanceOf(Date);
     });
@@ -253,8 +260,8 @@ describe("keen", function() {
                 it('should be able to return true', function () {
                     var clientScope = {
                         _queue: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
-                        options: {
-                            flushAt: 10
+                        _flushOptions: {
+                            atEventQuantity: 10
                         }
                     };
 
@@ -264,8 +271,8 @@ describe("keen", function() {
                 it('should be able to return false', function () {
                     var clientScope = {
                         _queue: [1, 2, 3],
-                        options: {
-                            flushAt: 10
+                        _flushOptions: {
+                            atEventQuantity: 10
                         }
                     };
 
@@ -282,8 +289,8 @@ describe("keen", function() {
 
                     var clientScope = {
                         _lastFlush: lastFlushTime,
-                        options: {
-                            flushAfter: 10000
+                        _flushOptions: {
+                            afterTime: 10000
                         }
                     };
 
@@ -294,8 +301,8 @@ describe("keen", function() {
                     var lastFlushTime = new Date();
                     var clientScope = {
                         _lastFlush: lastFlushTime,
-                        options: {
-                            flushAfter: 10000
+                        _flushOptions: {
+                            afterTime: 10000
                         }
                     };
 
@@ -311,12 +318,12 @@ describe("keen", function() {
         // * [ ] If S milliseconds has passed since the last flush.
 
         // Notes:
+        // * [x] Before flushing a message contains a promise.
+        // * [x] Configurable.
         // * [ ] If there are too many messages and the module cannot flush faster than it's 
         //   receiving messages, it will stop accepting messages instead of growing the queue
         //   until it runs out of memory... :)
-        // * [ ] Before flushing a message contains a promise.
         // * [ ] We should be able to flush manually.
-        // * [ ] Configurable.
 
         // Code:
         // * [x] Check things are constructed correctly.
@@ -325,8 +332,6 @@ describe("keen", function() {
         // * [ ] Implement _checkFlush().
         // * [ ] Implement flush().
         // * [ ] Implement _setTimer and _clearTimer().
-
-        // flush: { maxQueueSize, atEventQuantity, afterTime, timerInterval }
 
         describe('_enqueue()', function () {
             // Drop data if the queue has expanded beyond the max queue size.

--- a/test/test.js
+++ b/test/test.js
@@ -248,8 +248,8 @@ describe("keen", function() {
         //       We need to get the promise.
         //       It can be returned.
         //       But we shall also try to store the response logic against it.
-        //       We continue to pass in callbacks as before, in order to stay compatible.
-        // * [ ] Need serious rewrite. Reuse of request object is making queueing horrendous.
+        //       We continue to pass in callbacks as before in order to stay compatible.
+        // * [ ] Need serious rewrite. Tonnes of abstraction leakage with request.get, request.post and ...request.queuePost.
 
         describe('triggers', function () {
 
@@ -313,6 +313,9 @@ describe("keen", function() {
 
         });
 
+        // @todo: I need to test this in the literal sense, with proper examples
+        //        and logging to see when and how flushing is executed.
+
         // By default the library will flush:
         // * [ ] Every N messages.
         // * [ ] If S milliseconds has passed since the last flush.
@@ -331,7 +334,7 @@ describe("keen", function() {
         // * [ ] Implement _enqueue().
         // * [ ] Implement _checkFlush().
         // * [ ] Implement flush().
-        // * [ ] Implement _setTimer and _clearTimer().
+        // * [x] Implement _setTimer and _clearTimer().
 
         describe('_enqueue()', function () {
             // Drop data if the queue has expanded beyond the max queue size.
@@ -374,15 +377,24 @@ describe("keen", function() {
         });
 
         describe('_setTimer', function () {
-            // @todo: Do nothing for now but implement.
 
-            // If there is no timer, then create a timer with an interval.
+            it("should set a timer", function () {
+                // If there is no timer, then create a timer.
+                keen._setTimer();
+                should.exist(keen._timer);
+            });
         });
 
         describe('_clearTimer', function () {
-            // @todo: Do nothing for now but implement.
 
-            // Clear the timer if there is a timer.
+            it("should clear a timer", function () {
+                // Clear the timer if there is a timer.
+                keen._setTimer();
+                should.exist(keen._timer);
+
+                keen._clearTimer();
+                should.not.exist(keen._timer);
+            });
         });
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -315,31 +315,6 @@ describe("keen", function() {
 
         });
 
-        // @todo: I need to test this in the literal sense, with proper examples
-        //        and logging to see when and how flushing is executed.
-
-        // By default the library will flush:
-        // * [x] Every N messages.
-        // * [x] If S milliseconds has passed since the last flush.
-
-        // Notes:
-        // * [x] Before flushing a message contains a promise.
-        // * [x] Configurable.
-        // * [x] If there are too many messages and the module cannot flush faster than it's 
-        //   receiving messages, it will stop accepting messages instead of growing the queue
-        //   until it runs out of memory... :)
-        // * [x] We should be able to flush manually.
-
-        // Code:
-        // * [x] Check things are constructed correctly.
-        // * [x] Create small triggers.
-        // * [x] Implement _enqueue().
-        // * [x] Implement _shouldFlush().
-        // * [ ] Implement flush().
-        // * [x] Implement _setTimer and _clearTimer().
-
-        // @todo: Remove the WIP comments above.
-
         describe('_enqueue()', function () {
             beforeEach(function (){
                 keen = require("../");
@@ -500,6 +475,7 @@ describe("keen", function() {
                 keen._setTimer();
                 should.exist(keen._timer);
             });
+
         });
 
         describe('_clearTimer', function () {
@@ -512,6 +488,7 @@ describe("keen", function() {
                 keen._clearTimer();
                 should.not.exist(keen._timer);
             });
+
         });        
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -237,33 +237,12 @@ describe("keen", function() {
     describe('flushing', function () {
 
         // First things first:
-        // * [ ] A small refactor to handle promises/callbacks better.
+        // * [x] A small refactor to handle promises/callbacks better.
         //       We need to get the promise.
         //       It can be returned.
         //       But we shall also try to store the response logic against it.
         //       We continue to pass in callbacks as before, in order to stay compatible.
-
-        // By default the library will flush:
-        // * [ ] The very first time it gets a message.
-        // * [ ] Every N messages.
-        // * [ ] If S seconds has passed since the last flush.
-
-        // Notes:
-        // * [ ] If there are too many messages and the module cannot flush faster than it's 
-        //   receiving messages, it will stop accepting messages instead of growing the queue
-        //   until it runs out of memory... :)
-        // * [ ] Before flushing a message contains a promise.
-        // * [ ] We should be able to flush manually.
-        // * [ ] Configurable.
-
-        // Code:
-        // * [x] Check things are constructed correctly.
-        // * [x] Create small triggers.
-        // * [ ] Check to see whether the methods are returning promises?
-        // * [ ] Implement _enqueue().
-        // * [ ] Implement _checkFlush().
-        // * [ ] Implement flush().
-        // * [ ] Implement _clearTimer().
+        // * [ ] Need serious rewrite. Reuse of request object is making queueing horrendous.
 
         describe('triggers', function () {
 
@@ -327,8 +306,78 @@ describe("keen", function() {
 
         });
 
-        describe('_enqueue()', function () {
+        // By default the library will flush:
+        // * [ ] Every N messages.
+        // * [ ] If S milliseconds has passed since the last flush.
 
+        // Notes:
+        // * [ ] If there are too many messages and the module cannot flush faster than it's 
+        //   receiving messages, it will stop accepting messages instead of growing the queue
+        //   until it runs out of memory... :)
+        // * [ ] Before flushing a message contains a promise.
+        // * [ ] We should be able to flush manually.
+        // * [ ] Configurable.
+
+        // Code:
+        // * [x] Check things are constructed correctly.
+        // * [x] Create small triggers.
+        // * [ ] Implement _enqueue().
+        // * [ ] Implement _checkFlush().
+        // * [ ] Implement flush().
+        // * [ ] Implement _setTimer and _clearTimer().
+
+        // flush: { maxQueueSize, atEventQuantity, afterTime, timerInterval }
+
+        describe('_enqueue()', function () {
+            // Drop data if the queue has expanded beyond the max queue size.
+            // Log an error message.
+
+            // Push to the queue.
+
+            // Check to see whether the timer was set.
+
+            // Check whether it should be flushing.
+        });
+
+        describe('_checkFlush()', function () {
+            // @todo: To begin with just flush immediately.
+
+            // then:
+
+            // Loop through the triggers, whichs should be set against the client.
+            // *OR* with a variable `shouldFlush`, on triggering against the scope.
+
+            // Call flush if true, and false otherwise.
+
+            // Return true or false.
+        });
+
+        describe('flush()', function () {
+            // Given an empty queue, do nothing.
+
+            // If the queue length is non-zero, then...
+            // create a batch by splicing up until `this.options.flushAt`
+            // also, test that this reduces the size of the queue.
+
+            // Get a list of promises.
+
+            // Make each of the requests in the batch.
+
+            // Set `this._lastFlush` to the current date.
+
+            // If the queue length gets to zero, then clear the timer.
+        });
+
+        describe('_setTimer', function () {
+            // @todo: Do nothing for now but implement.
+
+            // If there is no timer, then create a timer with an interval.
+        });
+
+        describe('_clearTimer', function () {
+            // @todo: Do nothing for now but implement.
+
+            // Clear the timer if there is a timer.
         });
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -37,6 +37,9 @@ describe("keen", function() {
         keen.masterKey.should.equal(masterKey);
         keen.baseUrl.should.equal("https://api.keen.io/");
         keen.apiVersion.should.equal("3.0");
+
+        keen._queue.should.eql([]);
+        keen._lastFlush.should.be.instanceOf(Date);
     });
 
     it("configure should allow overriding baseUrl and apiVersion", function() {
@@ -234,28 +237,90 @@ describe("keen", function() {
     describe('flushing', function () {
 
         // By default the library will flush:
-        // * The very first time it gets a message.
-        // * Every N messages.
-        // * If S seconds has passed since the last flush.
+        // * [ ] The very first time it gets a message.
+        // * [ ] Every N messages.
+        // * [ ] If S seconds has passed since the last flush.
 
         // Notes:
-        // * If there are too many messages and the module cannot flush faster than it's 
+        // * [ ] If there are too many messages and the module cannot flush faster than it's 
         //   receiving messages, it will stop accepting messages instead of growing the queue
         //   until it runs out of memory... :)
-        // * Before flushing a message contains a promise.
-        // * We should be able to flush manually.
-        // * Configurable.
+        // * [ ] Before flushing a message contains a promise.
+        // * [ ] We should be able to flush manually.
+        // * [ ] Configurable.
 
         // Code:
-        // * Create small triggers.
-        // * Check things are constructed correctly.
-        // * Check to see whether the methods are returning promises?
-        // * Implement _enqueue().
-        // * Implement _checkFlush().
-        // * Implement flush().
-        // * Implement _clearTimer().
+        // * [x] Check things are constructed correctly.
+        // * [ ] Create small triggers.
+        // * [ ] Check to see whether the methods are returning promises?
+        // * [ ] Implement _enqueue().
+        // * [ ] Implement _checkFlush().
+        // * [ ] Implement flush().
+        // * [ ] Implement _clearTimer().
 
-        describe('enqueue()', function () {
+        describe('triggers', function () {
+
+            var triggers = require('../lib/triggers');
+
+            describe('#isQueueBeyondLimit()', function () {
+
+                it('should be able to return true', function () {
+                    var clientScope = {
+                        _queue: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+                        options: {
+                            flushAt: 10
+                        }
+                    };
+
+                    triggers.isQueueBeyondLimit.apply(clientScope).should.be.true;
+                });
+
+                it('should be able to return false', function () {
+                    var clientScope = {
+                        _queue: [1, 2, 3],
+                        options: {
+                            flushAt: 10
+                        }
+                    };
+
+                    triggers.isQueueBeyondLimit.apply(clientScope).should.be.false;
+                });
+
+            });
+
+            describe('#hasTimePassedSinceLastFlush()', function () {
+                
+                it('should be able to return true', function () {
+                    var lastFlushTime = new Date();
+                    lastFlushTime = lastFlushTime.setDate(lastFlushTime.getDate() - 7);
+
+                    var clientScope = {
+                        _lastFlush: lastFlushTime,
+                        options: {
+                            flushAfter: 10000
+                        }
+                    };
+
+                    triggers.hasTimePassedSinceLastFlush.apply(clientScope).should.be.true;
+                });
+
+                it('should be able to return false', function () {
+                    var lastFlushTime = new Date();
+                    var clientScope = {
+                        _lastFlush: lastFlushTime,
+                        options: {
+                            flushAfter: 10000
+                        }
+                    };
+
+                    triggers.hasTimePassedSinceLastFlush.apply(clientScope).should.be.false;
+                });
+
+            });
+
+        });
+
+        describe('_enqueue()', function () {
 
         });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -236,6 +236,13 @@ describe("keen", function() {
 
     describe('flushing', function () {
 
+        // First things first:
+        // * [ ] A small refactor to handle promises/callbacks better.
+        //       We need to get the promise.
+        //       It can be returned.
+        //       But we shall also try to store the response logic against it.
+        //       We continue to pass in callbacks as before, in order to stay compatible.
+
         // By default the library will flush:
         // * [ ] The very first time it gets a message.
         // * [ ] Every N messages.
@@ -251,7 +258,7 @@ describe("keen", function() {
 
         // Code:
         // * [x] Check things are constructed correctly.
-        // * [ ] Create small triggers.
+        // * [x] Create small triggers.
         // * [ ] Check to see whether the methods are returning promises?
         // * [ ] Implement _enqueue().
         // * [ ] Implement _checkFlush().

--- a/test/test.js
+++ b/test/test.js
@@ -230,4 +230,33 @@ describe("keen", function() {
             });
         });
     });
+
+    describe('flushing', function () {
+
+        // By default the library will flush:
+        // * The very first time it gets a message.
+        // * Every N messages.
+        // * If S seconds has passed since the last flush.
+
+        // Notes:
+        // * If there are too many messages and the module cannot flush faster than it's 
+        //   receiving messages, it will stop accepting messages instead of growing the queue
+        //   until it runs out of memory... :)
+        // * Before flushing a message contains a promise.
+        // * We should be able to flush manually.
+        // * Configurable.
+
+        // Code:
+        // * Create small triggers.
+        // * Check things are constructed correctly.
+        // * Check to see whether the methods are returning promises?
+        // * Implement _enqueue().
+        // * Implement _checkFlush().
+        // * Implement flush().
+        // * Implement _clearTimer().
+
+        describe('enqueue()', function () {
+
+        });
+    });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,14 +1,14 @@
 /* jshint quotmark:false,indent:4,maxlen:600 */
 var should = require("should");
 
-describe("keen", function() {
+describe("keen", function () {
 
     var keen;
     var projectId = "fakeProjectId";
     var writeKey = "fakeWriteKey";
     var nock = require("nock");
 
-    beforeEach(function() {
+    beforeEach(function () {
         nock.cleanAll();
         keen = require("../");
         keen = keen.configure({
@@ -17,7 +17,7 @@ describe("keen", function() {
         });
     });
 
-    it("configure should set up client correctly", function() {
+    it("configure should set up client correctly", function () {
         keen = require("../");
         var projectId = "projectId";
         var writeKey = "writeKey";
@@ -40,7 +40,7 @@ describe("keen", function() {
 
         keen._flushOptions.should.eql({
             atEventQuantity: 20,
-            afterTime: 10000, 
+            afterTime: 10000,
             maxQueueSize: 10000,
             timerInterval: 10000
         });
@@ -49,7 +49,7 @@ describe("keen", function() {
         keen._lastFlush.should.be.instanceOf(Date);
     });
 
-    it("configure should allow overriding baseUrl and apiVersion", function() {
+    it("configure should allow overriding baseUrl and apiVersion", function () {
         keen = require("../");
         var projectId = "projectId";
         var baseUrl = "blah";
@@ -66,10 +66,10 @@ describe("keen", function() {
         keen.apiVersion.should.equal(apiVersion);
     });
 
-    it("configure should error on bad input", function() {
+    it("configure should error on bad input", function () {
         keen = require("../");
 
-        var badInputHelper = function(config, expectedErrorMessage) {
+        var badInputHelper = function (config, expectedErrorMessage) {
             try {
                 keen.configure();
                 should.fail();
@@ -86,64 +86,82 @@ describe("keen", function() {
         badInputHelper({}, "The 'config' parameter must be specified and must be a JS object.");
     });
 
-    it("addEvent should require a writeKey", function(done) {
+    it("addEvent should require a writeKey", function (done) {
         keen = require("../");
 
         keen = keen.configure({
             projectId: projectId
         });
 
-        keen.addEvent("eventCollection", {}, function(error) {
+        keen.addEvent("eventCollection", {}, function (error) {
             should.exist(error);
             error.message.should.equal("You must specify a non-null, non-empty 'writeKey' in your 'config' object when calling keen.configure()!");
             done();
         });
     });
 
-    var mockPostRequest = function(path, responseCode, responseBody) {
+    var mockPostRequest = function (path, responseCode, responseBody) {
         nock("https://api.keen.io")
-        .post(path)
-        .reply(responseCode, responseBody, {"Content-Type": "application/json"});
+            .post(path)
+            .reply(responseCode, responseBody, {
+                "Content-Type": "application/json"
+            });
     };
 
-    var mockGetRequest = function(path, responseCode, responseBody) {
+    var mockGetRequest = function (path, responseCode, responseBody) {
         nock("https://api.keen.io")
-        .get(path)
-        .reply(responseCode, responseBody, {"Content-Type": "application/json"});
+            .get(path)
+            .reply(responseCode, responseBody, {
+                "Content-Type": "application/json"
+            });
     };
 
-    it("addEvent should make correct HTTP request", function(done) {
+    it("addEvent should make correct HTTP request", function (done) {
         var eventCollection = "purchases";
 
-        mockPostRequest("/3.0/projects/" + projectId + "/events/" + eventCollection, 201, {success: true});
+        mockPostRequest("/3.0/projects/" + projectId + "/events/" + eventCollection, 201, {
+            success: true
+        });
 
-        keen.addEvent(eventCollection, {"a": "b"}, function(error, responseBody) {
+        keen.addEvent(eventCollection, {
+            "a": "b"
+        }, function (error, responseBody) {
             should.not.exist(error);
-            JSON.stringify(responseBody).should.equal(JSON.stringify({success: true}));
+            JSON.stringify(responseBody).should.equal(JSON.stringify({
+                success: true
+            }));
             done();
         });
     });
 
-    it("addEvents should make correct HTTP request", function(done) {
+    it("addEvents should make correct HTTP request", function (done) {
         mockPostRequest("/3.0/projects/" + projectId + "/events", 200, {
-            "collection1": [{success: true}]
+            "collection1": [{
+                success: true
+            }]
         });
 
         keen.addEvents({
-            "collection1": [{"a": "b"}]
-        }, function(error, responseBody) {
+            "collection1": [{
+                "a": "b"
+            }]
+        }, function (error, responseBody) {
             should.not.exist(error);
-            JSON.stringify(responseBody).should.equal(JSON.stringify({"collection1": [{success: true}]}));
+            JSON.stringify(responseBody).should.equal(JSON.stringify({
+                "collection1": [{
+                    success: true
+                }]
+            }));
             done();
         });
     });
 
-    it("encrypt should generate a usable scoped key", function() {
+    it("encrypt should generate a usable scoped key", function () {
         keen = require("../");
         var apiKey = "80ce00d60d6443118017340c42d1cfaf";
         var options = {
             "allowed_operations": ["read"],
-            "filters": [ {
+            "filters": [{
                 "property_name": "purchase.amount",
                 "operator": "eq",
                 "property_value": 56
@@ -160,25 +178,30 @@ describe("keen", function() {
         decryptedOptions.should.eql(options);
     });
 
-    it("decrypt should return the correct options", function() {
+    it("decrypt should return the correct options", function () {
         keen = require("../");
         var apiKey = "f5d7c745ba4f437a82db02ca8b416556";
         var scopedKey = "7b8f357fa55e35efb2f7fa51a03ec2835c5537e57457c5a7c1c40c454fc00d5addef7ed911303fc2fa9648d3ae13e638192b86e90cd88657c9dc5cf03990cbf6eb2a7994513d34789bd25447f3dccaf5a3de3b9cacf6c11ded581e0506fca147ea32c13169787bbf8b4d3b8f2952bc0bea1beae3cfbbeaa1f421be2eac4cc223";
         var options = keen.decryptScopedKey(apiKey, scopedKey);
         var expected = {
-            filters:[ { property_name: 'account_id',
-            operator: 'eq',
-            property_value: '4d9a4c421d011c553e000001' } ]
+            filters: [{
+                property_name: 'account_id',
+                operator: 'eq',
+                property_value: '4d9a4c421d011c553e000001'
+            }]
         };
         expected.should.eql(options);
     });
 
-    it("should handle API errors", function(done) {
+    it("should handle API errors", function (done) {
         var id = 'foo';
-        var mockResponse = {error_code: 'FooError', message: 'no foo'};
-        mockPostRequest("/3.0/projects/"+projectId+"/events/"+id, 500, mockResponse);
+        var mockResponse = {
+            error_code: 'FooError',
+            message: 'no foo'
+        };
+        mockPostRequest("/3.0/projects/" + projectId + "/events/" + id, 500, mockResponse);
 
-        keen.addEvent(id, {}, function(err) {
+        keen.addEvent(id, {}, function (err) {
             err.should.be.an.instanceOf(Error);
             err.should.have.property('message', mockResponse.message);
             err.should.have.property('code', mockResponse.error_code);
@@ -186,36 +209,38 @@ describe("keen", function() {
         });
     });
 
-    describe('request', function() {
-        it("should expect a GET/POST/DEL method", function() {
-            should(function() {
+    describe('request', function () {
+        it("should expect a GET/POST/DEL method", function () {
+            should(function () {
                 keen.request('foo', 'write', '/');
             }).throwError('Method must be of type: GET/POST/DEL');
         });
 
-        it("should expect a write/read/master keytype", function() {
-            should(function() {
+        it("should expect a write/read/master keytype", function () {
+            should(function () {
                 keen.request('get', 'foo', '/');
             }).throwError('Key must be of type: master/write/read');
         });
 
-        it("should require a string path", function() {
-            should(function() {
+        it("should require a string path", function () {
+            should(function () {
                 keen.request('get', 'read');
             }).throwError('\'path\' must be a string.');
         });
 
-        it("should expect a key to be set", function() {
-            should(function() {
+        it("should expect a key to be set", function () {
+            should(function () {
                 keen.request('get', 'read', '/');
             }).throwError('You must specify a nun-null, non-empty \'readKey\' in your config object.');
         });
 
-        describe('send the request', function() {
+        describe('send the request', function () {
             var projectId = "projectId";
             var baseUrl = "https://api.keen.io/";
             var apiVersion = "3.0";
-            var mockResponse = {result: 1};
+            var mockResponse = {
+                result: 1
+            };
             var keen = require('../').configure({
                 projectId: projectId,
                 baseUrl: baseUrl,
@@ -223,17 +248,19 @@ describe("keen", function() {
                 readKey: 'foo'
             });
 
-            it('should send the request', function() {
-                mockGetRequest("/3.0/projects/"+projectId+"/queries/count?event_collection=foo", 200, mockResponse);
-                keen.request('get', 'read', '/queries/count', {event_collection:'foo'}, function(err, res) {
+            it('should send the request', function () {
+                mockGetRequest("/3.0/projects/" + projectId + "/queries/count?event_collection=foo", 200, mockResponse);
+                keen.request('get', 'read', '/queries/count', {
+                    event_collection: 'foo'
+                }, function (err, res) {
                     (err === null).should.be.true;
                     res.should.eql(mockResponse);
                 });
             });
 
-            it('has optional params', function() {
-                mockGetRequest("/3.0/projects/"+projectId+"/queries/count?event_collection=bar", 200, mockResponse);
-                keen.request('get', 'read', '/queries/count?event_collection=bar', function(err, res) {
+            it('has optional params', function () {
+                mockGetRequest("/3.0/projects/" + projectId + "/queries/count?event_collection=bar", 200, mockResponse);
+                keen.request('get', 'read', '/queries/count?event_collection=bar', function (err, res) {
                     (err === null).should.be.true;
                     res.should.eql(mockResponse);
                 });
@@ -284,7 +311,7 @@ describe("keen", function() {
             });
 
             describe('#hasTimePassedSinceLastFlush()', function () {
-                
+
                 it('should be able to return true', function () {
                     var lastFlushTime = new Date();
                     lastFlushTime = lastFlushTime.setDate(lastFlushTime.getDate() - 7);
@@ -316,7 +343,7 @@ describe("keen", function() {
         });
 
         describe('_enqueue()', function () {
-            beforeEach(function (){
+            beforeEach(function () {
                 keen = require("../");
                 keen = keen.configure({
                     projectId: projectId,
@@ -327,16 +354,22 @@ describe("keen", function() {
             it('should drop data if the queue has expanded beyond the max queue size', function () {
                 keen._flushOptions.maxQueueSize = 0;
                 keen._queue = [1, 2, 3, 4, 5];
-                keen._enqueue({ promise: null, callback: null }).should.be.false;
+                keen._enqueue({
+                    promise: null,
+                    callback: null
+                }).should.be.false;
             });
 
             it('should push to the queue on normal operation', function () {
                 keen.flush = function () { /* do nothing to the queue...! */ }
 
                 keen._queue.length.should.be.equal(0);
-                keen._enqueue({ promise: {
-                    end: function () {}
-                }, callback: function () {} }).should.be.true;
+                keen._enqueue({
+                    promise: {
+                        end: function () {}
+                    },
+                    callback: function () {}
+                }).should.be.true;
                 keen._queue.length.should.be.equal(1);
             });
 
@@ -344,20 +377,28 @@ describe("keen", function() {
                 var setTimerSpy = sinon.spy();
                 keen._setTimer = setTimerSpy;
 
-                keen._enqueue({ promise: {
-                    end: function () {}
-                }, callback: function () {} }).should.be.true;
+                keen._enqueue({
+                    promise: {
+                        end: function () {}
+                    },
+                    callback: function () {}
+                }).should.be.true;
                 setTimerSpy.called.should.be.true;
             });
 
             it('should call flush if _shouldFlush() returns true', function () {
                 var flushSpy = sinon.spy();
-                keen.flush = flushSpy;                
-                keen._shouldFlush = function () { return true; };
-                
-                keen._enqueue({ promise: {
-                    end: function () {}
-                }, callback: function () {} }).should.be.true;
+                keen.flush = flushSpy;
+                keen._shouldFlush = function () {
+                    return true;
+                };
+
+                keen._enqueue({
+                    promise: {
+                        end: function () {}
+                    },
+                    callback: function () {}
+                }).should.be.true;
                 flushSpy.called.should.be.true;
             });
         });
@@ -365,27 +406,27 @@ describe("keen", function() {
         describe('_shouldFlush()', function () {
 
             it("should return false if neither of the triggers returned true", function () {
-                keen._flushOptions.atEventQuantity = 10000;             
+                keen._flushOptions.atEventQuantity = 10000;
                 keen._flushOptions.afterTime = 1000000;
-                keen._queue = [];   
+                keen._queue = [];
                 keen._lastFlush = new Date();
 
                 keen._shouldFlush().should.be.false;
             });
 
             it("should return true if too much time passed since last flush", function () {
-                keen._flushOptions.atEventQuantity = 10000;             
+                keen._flushOptions.atEventQuantity = 10000;
                 keen._flushOptions.afterTime = 10000;
-                keen._queue = [];  
+                keen._queue = [];
 
                 var timeHasPassedSinceThis = new Date();
                 timeHasPassedSinceThis = timeHasPassedSinceThis.setDate(timeHasPassedSinceThis.getDate() - 7);
                 keen._lastFlush = timeHasPassedSinceThis;
-                
+
                 keen._shouldFlush().should.be.true;
             });
 
-            it("should return true if the length of the queue is too large", function () {            
+            it("should return true if the length of the queue is too large", function () {
                 keen._flushOptions.afterTime = 1000000;
                 keen._lastFlush = new Date();
 
@@ -399,7 +440,7 @@ describe("keen", function() {
 
         describe('flush()', function () {
 
-            beforeEach(function (){
+            beforeEach(function () {
                 keen = require("../");
                 keen = keen.configure({
                     projectId: projectId,
@@ -413,15 +454,42 @@ describe("keen", function() {
 
             it('should reduce the size of the queue by atEventQuantity', function () {
                 keen._flushOptions.atEventQuantity = 3;
-                keen._queue = [
-                    { promise: { end: function () {} }, callback: function () {} },
-                    { promise: { end: function () {} }, callback: function () {} },
-                    { promise: { end: function () {} }, callback: function () {} },
-                    { promise: { end: function () {} }, callback: function () {} },
-                    { promise: { end: function () {} }, callback: function () {} },
-                    { promise: { end: function () {} }, callback: function () {} },
-                    { promise: { end: function () {} }, callback: function () {} }
-                ];
+                keen._queue = [{
+                    promise: {
+                        end: function () {}
+                    },
+                    callback: function () {}
+                }, {
+                    promise: {
+                        end: function () {}
+                    },
+                    callback: function () {}
+                }, {
+                    promise: {
+                        end: function () {}
+                    },
+                    callback: function () {}
+                }, {
+                    promise: {
+                        end: function () {}
+                    },
+                    callback: function () {}
+                }, {
+                    promise: {
+                        end: function () {}
+                    },
+                    callback: function () {}
+                }, {
+                    promise: {
+                        end: function () {}
+                    },
+                    callback: function () {}
+                }, {
+                    promise: {
+                        end: function () {}
+                    },
+                    callback: function () {}
+                }];
                 keen.flush().should.be.true;
                 keen._queue.length.should.be.equal(4);
             });
@@ -430,10 +498,16 @@ describe("keen", function() {
                 keen._flushOptions.atEventQuantity = 1;
 
                 var eventCollection = "testCollection";
-                mockPostRequest("/3.0/projects/" + projectId + "/events/" + eventCollection, 201, {success: true});
-                keen.addEvent(eventCollection, {"a": "b"}, function (error, responseBody) {
+                mockPostRequest("/3.0/projects/" + projectId + "/events/" + eventCollection, 201, {
+                    success: true
+                });
+                keen.addEvent(eventCollection, {
+                    "a": "b"
+                }, function (error, responseBody) {
                     should.not.exist(error);
-                    JSON.stringify(responseBody).should.equal(JSON.stringify({ success: true }));
+                    JSON.stringify(responseBody).should.equal(JSON.stringify({
+                        success: true
+                    }));
                     done();
                 });
             });
@@ -441,11 +515,22 @@ describe("keen", function() {
             it('should change _lastFlush', function () {
                 var previousFlush = keen._lastFlush;
 
-                keen._queue = [
-                    { promise: { end: function () {} }, callback: function () {} },
-                    { promise: { end: function () {} }, callback: function () {} },
-                    { promise: { end: function () {} }, callback: function () {} }
-                ];
+                keen._queue = [{
+                    promise: {
+                        end: function () {}
+                    },
+                    callback: function () {}
+                }, {
+                    promise: {
+                        end: function () {}
+                    },
+                    callback: function () {}
+                }, {
+                    promise: {
+                        end: function () {}
+                    },
+                    callback: function () {}
+                }];
                 keen.flush().should.be.true;
 
                 keen._lastFlush.should.not.be.eql(previousFlush);
@@ -456,11 +541,22 @@ describe("keen", function() {
                 keen._clearTimer = clearTimerSpy;
 
                 keen._flushOptions.atEventQuantity = 10;
-                keen._queue = [
-                    { promise: { end: function () {} }, callback: function () {} },
-                    { promise: { end: function () {} }, callback: function () {} },
-                    { promise: { end: function () {} }, callback: function () {} }
-                ];
+                keen._queue = [{
+                    promise: {
+                        end: function () {}
+                    },
+                    callback: function () {}
+                }, {
+                    promise: {
+                        end: function () {}
+                    },
+                    callback: function () {}
+                }, {
+                    promise: {
+                        end: function () {}
+                    },
+                    callback: function () {}
+                }];
                 keen.flush().should.be.true;
                 keen._queue.length.should.be.equal(0);
                 clearTimerSpy.called.should.be.true;
@@ -489,6 +585,6 @@ describe("keen", function() {
                 should.not.exist(keen._timer);
             });
 
-        });        
+        });
     });
 });


### PR DESCRIPTION
I thought this should be added to this library.

It should mean that:
1. We lessen the possibility that a developer might call addEvent() or addEvents() too fast causing an out-of-memory error.
2. More control over when and how insert requests are made to Keen.IO.
3. Should make it slightly easier for somebody to implement the not-yet-implemented “batchEventInserts” option that is spoken of in the `README.md`. (You would have to alter the internal structure of the requestData objects I am creating and use these inside `this.flush()` to restructure multiple requests into per event collection addEvents() requests.)

I took a look at an approach another library took on this so it’s hopefully correct, albeit derivative. :)

There were some integration problems as the original library exposed a request method, and as I do not think you ever want to queue/flush anything but `addEvent()` and `addEvents()` calls, I ended up creating a special case. Unfortunately, I can’t be sure that somebody won’t skip the special case by accessing directly through `this.request()`. Also, I think it might make sense to split index.js up a little sooner or later.

So it probably needs a refactor. Maybe somebody sees a need to switch this off, or change the configuration object? Can anybody see any bugs?

Thoughts?

Seb
