### PR TITLE
[Security] update superagent

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     }
   ],
   "dependencies": {
-    "superagent": "~0.13.0",
+    "superagent": "~0.20.0",
     "underscore": "~1.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Superagent 0.13.0 depends of qs 0.5.2 which has a security issue (see https://nodesecurity.io/advisories/qs_dos_extended_event_loop_blocking). It is recommended to upgrade to a version >= 1.x, and it has been done in superagent 0.19.
