### PR TITLE
Support for query timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,22 @@ max_revenue.set({ timeframe: "this_21_days" });
 mashup.refresh();
 ```
 
+### Query timeouts
+
+```javascript
+// Specify a timeout in milliseconds
+var count = new Keen.Query("count", {
+  event_collection: "pageviews",
+  timeout: 1000
+});
+
+// When a query times out, an err is passed to the callback
+client.run(count, function(err, response){
+  if (err) return console.log(err);
+  // err.message == 'timeout of 1000ms exceeded'
+});
+```
+
 
 
 ## Future Updates

--- a/lib/requests.js
+++ b/lib/requests.js
@@ -36,9 +36,13 @@ function buildQueryString(params){
 
 module.exports = {
   get: function(apiKey, path, data, callback) {
+    data = data || {};
+    var timeout = data.timeout;
+    delete data.timeout;
     rest
     .get(this.baseUrl + this.apiVersion + path + buildQueryString(data))
     .set('Authorization', apiKey)
+    .timeout(timeout)
     .end(function(err, res) {
       processResponse(err, res, callback);
     });

--- a/test/test.js
+++ b/test/test.js
@@ -118,9 +118,11 @@ describe("keen", function() {
         .reply(responseCode, responseBody, {"Content-Type": "application/json"});
     };
 
-    var mockGetRequest = function(path, responseCode, responseBody) {
+    var mockGetRequest = function(path, responseCode, responseBody, delay) {
+        delay = delay || 0;
         nock("https://api.keen.io")
         .get(path)
+        .delay(delay)
         .reply(responseCode, responseBody, {"Content-Type": "application/json"});
     };
 
@@ -255,6 +257,14 @@ describe("keen", function() {
                     (err === null).should.be.true;
                     res.should.eql(mockResponse);
                 });
+            });
+
+            it('times out', function() {
+              mockGetRequest("/"+ apiVersion +"/projects/"+projectId+"/queries/count?event_collection=bar", 200, mockResponse, 1000);
+              keen.request('get', 'read', '/queries/count', {event_collection:'bar', timeout: 1}, function(error) {
+                should.exist(error);
+                error.message.should.equal("timeout of 1ms exceeded");
+              });
             });
         });
     });


### PR DESCRIPTION
This PR adds support for the optional `timeout` parameter which is used to set the request timeout when calling Keen.IO.