### PR TITLE
Adds ability to list all collections in a project

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,15 @@ function KeenApi(config) {
 
 	this.collections = {
 		view: function(projectId, collection, callback) {
-			KeenRequests.get.call(self, self.masterKey, '/projects/' + projectId + '/events/' + collection, null, callback);
+			// Make collection argument optional so that the Events Resource can be properly
+			// queried, as specified in the docs.
+			if (collection && !/^\//.test(collection)) {
+				collection = '/' + collection;
+			} else {
+				// Make sure falsey values are assigned to a string.
+				collection = '';
+			}
+			KeenRequests.get.call(self, self.masterKey, '/projects/' + projectId + '/events' + collection, null, callback);
 		},
 		remove: function(projectId, collection, callback) {
 			KeenRequests.del.call(self, self.masterKey, '/projects/' + projectId + '/events/' + collection, callback);


### PR DESCRIPTION
Kinda quirky, but `https://api.keen.io/<api_version>/projects/<project_id>/events/` (with a trailing slash) returns `Resource not found`. This gets around that, allowing users to get a list of collections in a project.

Example usage: 
```javascript
keen.collections.view(keen.projectId, null, function(err, res) {
    console.log('collection.view', err, res);
});
```

The above currently throws the resource not found error.