### PR TITLE
only call error callback once

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -1,4 +1,5 @@
 var _ = require('underscore');
+var async = require('async');
 var KeenRequests = require('./requests');
 
 /*!
@@ -31,40 +32,47 @@ Keen.Request.prototype.run = function(){
       completions = 0,
       response = [];
 
-  var handleResponse = function(err, res){
+  var queue = [];
+
+  _.each(self.queries, function(query, index){
+    queue.push(function(qCallback){
+      var data, path = '/projects/' + self.client.projectId;
+      var callbackSequencer = function(err, res){
+        if(err){
+          return qCallback(err);
+        }
+
+        response[index] = res;
+
+        qCallback();
+      };
+
+      if (query instanceof Keen.Query) {
+        path += query.path;
+        data = query.params || {};
+      }
+      /* TODO: Test and deploy this
+      else if (_.isString(query)) {
+        path += '/saved_queries/' + query + '/result';
+        data = { api_key: self.client.readKey };
+      }*/
+      else {
+        throw new Error('Query #' + (index+1)  +' is not valid');
+
+      }
+
+      KeenRequests.get.call(self.client, self.client.readKey, path, data, callbackSequencer);
+    });
+  });
+
+  async.parallel(queue, function(err, results){
     if (err && self.callback) {
       return self.callback(err, null);
     }
-    response[arguments[2]] = res, completions++;
-    if (completions == self.queries.length) {
-      self.data = (self.queries.length == 1) ? response[0] : response;
-      if (self.callback) self.callback(null, self.data);
-    }
-  };
 
-  _.each(self.queries, function(query, index){
-    var data, path = '/projects/' + self.client.projectId;
-    var callbackSequencer = function(err, res){
-      handleResponse(err, res, index);
-    };
-
-    if (query instanceof Keen.Query) {
-      path += query.path;
-      data = query.params || {};
-    }
-    /* TODO: Test and deploy this
-    else if (_.isString(query)) {
-      path += '/saved_queries/' + query + '/result';
-      data = { api_key: self.client.readKey };
-    }*/
-    else {
-      throw new Error('Query #' + (index+1)  +' is not valid');
-
-    }
-
-    KeenRequests.get.call(self.client, self.client.readKey, path, data, callbackSequencer);
+    self.data = (self.queries.length == 1) ? response[0] : response;
+    if (self.callback) self.callback(null, self.data);
   });
-
   return self;
 };
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
   ],
   "dependencies": {
     "superagent": "~0.21.0",
-    "underscore": "~1.5.2"
+    "underscore": "~1.5.2",
+    "async": "0.9.0"
   },
   "devDependencies": {
     "mocha": "~1.16.1",

--- a/test/test.js
+++ b/test/test.js
@@ -503,6 +503,19 @@ describe("keen", function() {
 
             describe('Multiple analyses', function(){
 
+              it('should invoke the error callback only once', function(done){
+                var mockResponse = { result: 1 };
+                mockGetRequest(query_path, 401, mockResponse);
+                mockGetRequest(query_path, 401, mockResponse);
+                analysis.params = {};
+                var test = keen.run([analysis, analysis, analysis], function(err, res){
+                  (err === null).should.be.false;
+                  (res === null).should.be.true;
+
+                  done();
+                });
+              });
+
               it('should return a single response when successful', function(done){
                 var mockResponse = { result: 1 };
                 mockGetRequest(query_path, 200, mockResponse);


### PR DESCRIPTION
Fix for #34, could probably be improved by capturing multiple errors and returning them all vs. just the first (this method allows the query to fail fast).